### PR TITLE
Error if CORS is not enabled

### DIFF
--- a/src/jws-compact.ts
+++ b/src/jws-compact.ts
@@ -240,7 +240,7 @@ async function downloadAndImportKey(issuerURL: string, log: Log): Promise<keys.K
         // TODO: can we easily add a unit test for this?
         const acaoHeader = response.headers['access-control-allow-origin'];
         if (!acaoHeader) {
-            log.warn("Issuer key endpoint does not contain a 'access-control-allow-origin' header for Cross-Origin Resource Sharing (CORS)", ErrorCode.ISSUER_KEY_WELLKNOWN_ENDPOINT_CORS);
+            log.error("Issuer key endpoint does not contain a 'access-control-allow-origin' header for Cross-Origin Resource Sharing (CORS)", ErrorCode.ISSUER_KEY_WELLKNOWN_ENDPOINT_CORS);
         } else if (acaoHeader !== '*' && acaoHeader !== requestedOrigin) {
             log.warn(`Issuer key endpoint's 'access-control-allow-origin' header ${acaoHeader} does not match the requested origin ${requestedOrigin}, for Cross-Origin Resource Sharing (CORS)`, ErrorCode.ISSUER_KEY_WELLKNOWN_ENDPOINT_CORS);
         }


### PR DESCRIPTION
From https://spec.smarthealth.cards/#determining-keys-associated-with-an-issuer:

> Issuers SHALL publish their public keys as JSON Web Key Sets (see RFC7517), available at <<iss value from JWS>> + /.well-known/jwks.json, with Cross-Origin Resource Sharing (CORS) enabled.

