### PR TITLE
Add warning for optional/unknown vc types

### DIFF
--- a/testdata/test-example-00-b-jws-payload-expanded-optional-vc-type.json
+++ b/testdata/test-example-00-b-jws-payload-expanded-optional-vc-type.json
@@ -1,0 +1,91 @@
+{
+  "iss": "https://spec.smarthealth.cards/examples/issuer",
+  "nbf": 1626733777.575,
+  "vc": {
+    "type": [
+      "VerifiableCredential",
+      "https://smarthealth.cards#health-card",
+      "https://smarthealth.cards#immunization",
+      "https://smarthealth.cards#covid19"
+    ],
+    "credentialSubject": {
+      "fhirVersion": "4.0.1",
+      "fhirBundle": {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+          {
+            "fullUrl": "resource:0",
+            "resource": {
+              "resourceType": "Patient",
+              "name": [
+                {
+                  "family": "Anyperson",
+                  "given": [
+                    "John",
+                    "B."
+                  ]
+                }
+              ],
+              "birthDate": "1951-01-20"
+            }
+          },
+          {
+            "fullUrl": "resource:1",
+            "resource": {
+              "resourceType": "Immunization",
+              "status": "completed",
+              "vaccineCode": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "207"
+                  }
+                ]
+              },
+              "patient": {
+                "reference": "resource:0"
+              },
+              "occurrenceDateTime": "2021-01-01",
+              "performer": [
+                {
+                  "actor": {
+                    "display": "ABC General Hospital"
+                  }
+                }
+              ],
+              "lotNumber": "0000001"
+            }
+          },
+          {
+            "fullUrl": "resource:2",
+            "resource": {
+              "resourceType": "Immunization",
+              "status": "completed",
+              "vaccineCode": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "207"
+                  }
+                ]
+              },
+              "patient": {
+                "reference": "resource:0"
+              },
+              "occurrenceDateTime": "2021-01-29",
+              "performer": [
+                {
+                  "actor": {
+                    "display": "ABC General Hospital"
+                  }
+                }
+              ],
+              "lotNumber": "0000007"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/testdata/test-example-00-b-jws-payload-expanded-unknown-vc-types.json
+++ b/testdata/test-example-00-b-jws-payload-expanded-unknown-vc-types.json
@@ -1,0 +1,92 @@
+{
+  "iss": "https://spec.smarthealth.cards/examples/issuer",
+  "nbf": 1626733777.575,
+  "vc": {
+    "type": [
+      "https://smarthealth.cards#extra-type-1",
+      "https://smarthealth.cards#health-card",
+      "https://smarthealth.cards#immunization",
+      "https://smarthealth.cards#covid19",
+      "https://smarthealth.cards#extra-type-2"
+    ],
+    "credentialSubject": {
+      "fhirVersion": "4.0.1",
+      "fhirBundle": {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+          {
+            "fullUrl": "resource:0",
+            "resource": {
+              "resourceType": "Patient",
+              "name": [
+                {
+                  "family": "Anyperson",
+                  "given": [
+                    "John",
+                    "B."
+                  ]
+                }
+              ],
+              "birthDate": "1951-01-20"
+            }
+          },
+          {
+            "fullUrl": "resource:1",
+            "resource": {
+              "resourceType": "Immunization",
+              "status": "completed",
+              "vaccineCode": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "207"
+                  }
+                ]
+              },
+              "patient": {
+                "reference": "resource:0"
+              },
+              "occurrenceDateTime": "2021-01-01",
+              "performer": [
+                {
+                  "actor": {
+                    "display": "ABC General Hospital"
+                  }
+                }
+              ],
+              "lotNumber": "0000001"
+            }
+          },
+          {
+            "fullUrl": "resource:2",
+            "resource": {
+              "resourceType": "Immunization",
+              "status": "completed",
+              "vaccineCode": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "207"
+                  }
+                ]
+              },
+              "patient": {
+                "reference": "resource:0"
+              },
+              "occurrenceDateTime": "2021-01-29",
+              "performer": [
+                {
+                  "actor": {
+                    "display": "ABC General Hospital"
+                  }
+                }
+              ],
+              "lotNumber": "0000007"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -339,3 +339,7 @@ test("Cards: fhir bundle w/ empty elements", testCard(['test-example-00-a-fhirBu
 test("Cards: missing SHC VC type", testCard('test-example-00-b-jws-payload-expanded-missing-shc-vc-type.json', 'jwspayload', [[ErrorCode.SCHEMA_ERROR]]));
 
 test("Cards: issuer not in trusted directory", testCard(['example-00-d-jws.txt'], 'jws', [[ErrorCode.ISSUER_NOT_TRUSTED]], { directory: 'VCI' }));
+
+test("Cards: un-needed VC type", testCard('test-example-00-b-jws-payload-expanded-optional-vc-type.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR]]));
+
+test("Cards: unknown VC types", testCard('test-example-00-b-jws-payload-expanded-unknown-vc-types.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR, ErrorCode.SCHEMA_ERROR]]));


### PR DESCRIPTION
- warns if 'verifiableCredential' vc type is used
- warns if unknown vc type is used (see: https://spec.smarthealth.cards/vocabulary/)

Closes #134