### PR TITLE
Removed non-US approved vaccines from the US profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Multiple `path` options can be provided for QR artifacts (`qrnumeric` and `qr` t
 
                  node . --path QR1.txt --path QR2.txt --path QR3.txt --type qrnumeric
 
-Specific FHIR profiles can be validated by using the `--profile` option; only the `usa-covid19-immunization` profile is currently supported.
+Specific FHIR profiles can be validated by using the `--profile` option; valid options are:
+ - `usa-covid19-immunization`, checking for vaccine products approved in the USA.
 
 A trusted issuers directory can be used by using the `--directory` option; by passing either a known directory name or by passing a URL pointing to a directory using the same format as the [VCI directory](https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json). The known directory names are:
  - `VCI`, corresponding to the VCI directory, and

--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -12,8 +12,9 @@ import Log from './logger';
 import beautify from 'json-beautify'
 import { propPath, walkProperties } from './utils';
 
-// CDC covid vaccine codes (https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html)
-export const cdcCovidCvxCodes = ["207", "208", "210", "211", "212"];
+// Subset of the CDC covid vaccine codes (https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html),
+// currently pre-authorized in the US (https://www.cdc.gov/vaccines/covid-19/info-by-product/index.html)
+export const cdcCovidCvxCodes = ["207", "208", "212"];
 
 // LOINC covid test codes (https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion)
 export const loincCovidTestCodes = ["50548-7", "68993-5", "82159-5", "94306-8", "94307-6", "94308-4", "94309-2", "94500-6", "94502-2", "94503-0", "94504-8", "94507-1", "94508-9", "94531-1", "94533-7", "94534-5", "94547-7", "94558-4", "94559-2", "94562-6", "94563-4", "94564-2", "94565-9", "94640-0", "94661-6", "94756-4", "94757-2", "94758-0", "94759-8", "94760-6", "94761-4", "94762-2", "94764-8", "94845-5", "95209-3", "95406-5", "95409-9", "95416-4", "95423-0", "95424-8", "95425-5", "95542-7", "95608-6", "95609-4"];


### PR DESCRIPTION
Removed cvx code not currectly approved in the US, from the `usa-covid19-immunization` profile.