### PR TITLE
leave package.json in js folder for npm install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,4 +15,5 @@ src
 testdata
 tsconfig.json
 !js/src/api.d.ts
+!js/package.json
 *.log


### PR DESCRIPTION
.npmignore removes a copy of package.json from the /js folder

/js/src/shc-validator.js makes a reference to this file and will error when being called after an npm install from github

Added an exception to .npmignore to preserve that file in the /js directory.